### PR TITLE
Add script to replace deploy path easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+build

--- a/README.md
+++ b/README.md
@@ -22,27 +22,41 @@ This project is a simple app that was bootstrapped with [Create React App](https
 
 1. This project is already ejected(`eject` in CRA), so you need to maintain all of the configurations yourself.
 
-2. If you want to change the version of ILib or root of this project, you can change them(`homepage`, `dependencies` in `package.json`, and `basename` in `src/index.js`).
+2. If you want to change the version of ILib or the root of this project, you can change them(`homepage`, `dependencies` in `package.json`, and `basename` in `src/index.js`).
+
    For example,
-```
-// package.json
-...
-"ilib": "14.18.0",
-...
-```
-```
+
+```json
 // package.json
 ...
 "ilib": "npm:ilib-webos@14.18.0-webos1",
 ...
 "homepage": "http://i18n.lge.com/ilib/localeSpecDoc/reference",
 ...
+```
+```js
 // src/index.js
 ...
 <BrowserRouter basename="/ilib/localeSpecDoc/reference">
 ...
 
 ```
+3. There is a script file to help the above #2 work easily.   
+First, Modify  `util/config.json` file. Then execute a `npm run updatePath` in the root. You will find the data is updated properly as you expect.
+Here is an example of a  `config.json` file.
+```json
+// config.json
+{
+    "packages": {
+        "homepage": "http://i18n.lge.com/ilib/localeSpecDoc/reference",
+        "ilibVersion": "npm:ilib-webos@14.18.0-webos1"
+    },
+    "index": {
+        "basename":"/ilib/localeSpecDoc/reference"
+    }
+}
+```
+
 
 ## Available Scripts
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,10 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "clean": "rm -rf build",
-    "postbuild": "react-snap"
+    "postbuild": "react-snap",
+    "modifyPath": "node util/replace.js util/config.json",
+    "copy": "cp tmp/package.json . ; cp tmp/index.js src/index.js",
+    "updatePath": "npm-run-all modifyPath copy"
   },
   "eslintConfig": {
     "extends": [
@@ -92,6 +95,7 @@
   },
   "devDependencies": {
     "@enact/dev-utils": "^6.0.2",
+    "npm-run-all": "^4.1.5",
     "react-snap": "^1.23.0"
   },
   "homepage": "https://ilib-js.github.io/ilib-localespec-doc/",

--- a/util/config.json
+++ b/util/config.json
@@ -1,0 +1,9 @@
+{
+    "packages": {
+        "homepage": "http://i18n.lge.com/ilib/localeSpecDoc/new_reference",
+        "ilibVersion": "npm:ilib-webos@14.18.0-webos1"
+    },
+    "index": {
+        "basename":"/ilib/localeSpecDoc/new_reference"
+    }
+}

--- a/util/replace.js
+++ b/util/replace.js
@@ -30,7 +30,7 @@ indexJSFile(configData);
 
 function packageJSONFile(configData) {
     console.log("Modify package.json ...");
-    var orgPkgData = JSON.parse(fs.readFileSync("../package.json", "utf-8"));
+    var orgPkgData = JSON.parse(fs.readFileSync("./package.json", "utf-8"));
     orgPkgData["homepage"] = configData.packages.homepage;
     if (typeof configData.packages.ilibVersion !== 'undefined') {
         orgPkgData["dependencies"]["ilib"] = configData.packages.ilibVersion;

--- a/util/replace.js
+++ b/util/replace.js
@@ -1,0 +1,46 @@
+var fs = require('fs');
+var path = require('path');
+
+function usage() {
+    console.log("Usage: replace.js [-h] [config] [toOutput]\n" +
+        "Generate number formats information files.\n\n" +
+        "-h or --help\n" +
+        "  this help\n" +
+        "toDir\n" +
+        "  directory to output the package.json Default: ./tmp");
+    process.exit(1);
+}
+
+process.argv.forEach(function (val, index, array) {
+    if (val === "-h" || val === "--help") {
+        usage();
+    }
+});
+
+var config = process.argv[2] || "./config.json";
+var toOutput = process.argv[3] || "./tmp";
+
+if (!fs.existsSync(toOutput)){
+    fs.mkdirSync(toOutput, {recursive:true});
+}
+var regExp = /(\<BrowserRouter basename\=\")(.*)(\"\>)/;
+var configData = JSON.parse(fs.readFileSync(config, "utf-8"));
+packageJSONFile(configData);
+indexJSFile(configData);
+
+function packageJSONFile(configData) {
+    console.log("Modify package.json ...");
+    var orgPkgData = JSON.parse(fs.readFileSync("../package.json", "utf-8"));
+    orgPkgData["homepage"] = configData.packages.homepage;    
+    fs.writeFileSync(path.join(toOutput, "package.json"), JSON.stringify(orgPkgData, true, 2), "utf-8");
+}
+
+function indexJSFile(configData) {
+    console.log("Modify src/index.js ...");
+    var jsContent = fs.readFileSync("./src/index.js", "utf-8");
+    var updated = jsContent.replace(regExp, `$1` + configData.index.basename + `$3`);
+    fs.writeFileSync(path.join(toOutput, "index.js"), updated, "utf-8");
+    
+}
+
+console.log("Done");

--- a/util/replace.js
+++ b/util/replace.js
@@ -31,7 +31,10 @@ indexJSFile(configData);
 function packageJSONFile(configData) {
     console.log("Modify package.json ...");
     var orgPkgData = JSON.parse(fs.readFileSync("../package.json", "utf-8"));
-    orgPkgData["homepage"] = configData.packages.homepage;    
+    orgPkgData["homepage"] = configData.packages.homepage;
+    if (typeof configData.packages.ilibVersion !== 'undefined') {
+        orgPkgData["dependencies"]["ilib"] = configData.packages.ilibVersion;
+    }
     fs.writeFileSync(path.join(toOutput, "package.json"), JSON.stringify(orgPkgData, true, 2), "utf-8");
 }
 

--- a/util/replace.js
+++ b/util/replace.js
@@ -3,11 +3,11 @@ var path = require('path');
 
 function usage() {
     console.log("Usage: replace.js [-h] [config] [toOutput]\n" +
-        "Generate number formats information files.\n\n" +
+        "Update files by using config data.\n\n" +
         "-h or --help\n" +
         "  this help\n" +
         "toDir\n" +
-        "  directory to output the package.json Default: ./tmp");
+        "  directory to place output files.: ./tmp");
     process.exit(1);
 }
 
@@ -31,19 +31,21 @@ indexJSFile(configData);
 function packageJSONFile(configData) {
     console.log("Modify package.json ...");
     var orgPkgData = JSON.parse(fs.readFileSync("./package.json", "utf-8"));
+
     orgPkgData["homepage"] = configData.packages.homepage;
     if (typeof configData.packages.ilibVersion !== 'undefined') {
         orgPkgData["dependencies"]["ilib"] = configData.packages.ilibVersion;
     }
+
     fs.writeFileSync(path.join(toOutput, "package.json"), JSON.stringify(orgPkgData, true, 2), "utf-8");
 }
 
 function indexJSFile(configData) {
     console.log("Modify src/index.js ...");
     var jsContent = fs.readFileSync("./src/index.js", "utf-8");
+
     var updated = jsContent.replace(regExp, `$1` + configData.index.basename + `$3`);
     fs.writeFileSync(path.join(toOutput, "index.js"), updated, "utf-8");
-    
 }
 
 console.log("Done");


### PR DESCRIPTION
* Add script to replace deploy path easily
 Only need to update  `config.json`. Then, when you run the script, it easily updates the files that need to be updated for different places to deploy