### PR TITLE
Fix to use the useMemo correctly

### DIFF
--- a/src/pages/BasicInfo.js
+++ b/src/pages/BasicInfo.js
@@ -14,7 +14,7 @@ import ScriptInfo from 'ilib/lib/ScriptInfo';
 const BasicInfo = ({locale}) => {
   const li = useMemo(() => new LocaleInfo(locale), [locale]);
   const si = useMemo(() => new ScriptInfo(li.getScript()), [li]);
-  const weekName = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  const weekName = useMemo(() => ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'], []);
   const rows = useMemo(() => [
     ['System Locale', locale],
     ['Locale Descripton', li.getLanguageName() + ' , ' + li.getRegionName() + ' (' + li.getScript() + ')'],
@@ -27,7 +27,7 @@ const BasicInfo = ({locale}) => {
     ['Weekend End at', weekName[li.getWeekEndEnd()]],
     ['Delimiter Quotation Start', li.getDelimiterQuotationStart()],
     ['Delimiter Quotation End', li.getDelimiterQuotationEnd()]
-  ], [locale, li, si]);
+  ], [locale, li, si, weekName]);
 
   return (
     <Box sx={{marginTop: 4, marginBottom: 5}}>


### PR DESCRIPTION
Fix to use the useMemo correctly regarding my previous commit (https://github.com/iLib-js/ilib-localespec-doc/pull/9)
There were the warning messages below:
```
src/pages/BasicInfo.js
  Line 18:20:  React Hook useMemo does nothing when called with only one argument. Did you forget to pass an array of dependencies?  react-hooks/exhaustive-deps
  Line 31:6:   React Hook useMemo has a missing dependency: 'weekName'. Either include it or remove the dependency array  
```